### PR TITLE
Fix metrics publishing

### DIFF
--- a/dns-service/bootstrap.sh
+++ b/dns-service/bootstrap.sh
@@ -15,13 +15,13 @@ start_dns_server() {
 }
 
 boot_metrics_agent() {
-  ruby ./metrics/lib/agent.rb
+  ruby ./metrics/lib/agent.rb &
 }
 
 main() {
   fetch_bind_config_file
-  start_dns_server
   boot_metrics_agent
+  start_dns_server
 }
 
 main

--- a/dns-service/metrics/lib/agent.rb
+++ b/dns-service/metrics/lib/agent.rb
@@ -1,5 +1,15 @@
 require_relative "dns_metrics"
 
+# Wait for DNS server to start
+10.times do
+  BindClient.new.get_server_stats
+rescue Errno::EADDRNOTAVAIL => e
+  sleep 1
+  next # Server is still booting so try again
+else
+  break # Server is up so we can continue
+end
+
 while true
   puts "before metrics"
   server_stats = BindClient.new.get_server_stats

--- a/dns-service/metrics/lib/agent.rb
+++ b/dns-service/metrics/lib/agent.rb
@@ -12,11 +12,10 @@ end
 
 while true
   puts "before metrics"
-  server_stats = BindClient.new.get_server_stats
-  zone_stats = BindClient.new.get_zone_stats
   PublishMetrics.new(
-    client: AwsClient.new
-  ).execute(server_stats: server_stats, zone_stats: zone_stats)
+    aws_client: AwsClient.new,
+    bind_client: BindClient.new
+  ).execute
   puts "after metrics"
   sleep 10
 end

--- a/dns-service/metrics/lib/publish_metrics.rb
+++ b/dns-service/metrics/lib/publish_metrics.rb
@@ -1,16 +1,20 @@
 require "time"
 
 class PublishMetrics
-  def initialize(client:)
-    @client = client
+  def initialize(aws_client:, bind_client:)
+    @aws_client = aws_client
+    @bind_client = bind_client
     @time = DateTime.now.to_time.to_i
   end
 
-  def execute(server_stats:, zone_stats:)
+  def execute
+    server_stats = bind_client.server_stats
+    zone_stats = bind_client.zone_stats
+
     raise "BIND server stats are empty" if server_stats.empty?
     raise "BIND zones stats are empty" if zone_stats.empty?
 
-    client.put_metric_data(generate_cloudwatch_metrics(server_stats) + generate_zone_metrics(zone_stats))
+    aws_client.put_metric_data(generate_cloudwatch_metrics(server_stats) + generate_zone_metrics(zone_stats))
   end
 
   private
@@ -32,5 +36,5 @@ class PublishMetrics
     {dimensions: [], metric_name: key, timestamp: @time, value: value}
   end
 
-  attr_reader :client
+  attr_reader :aws_client, :bind_client
 end


### PR DESCRIPTION
We found daemonising the DNS server to be too problematic so instead we are daemonising the metrics agent and running it before the server starts.

As we are running the agent in the background, we need to add a check to make sure the server is up before we start publishing metrics (otherwise the agent will throw an exception and stop)