### PR TITLE
Extract API check to its own class

### DIFF
--- a/dns-service/metrics/Gemfile
+++ b/dns-service/metrics/Gemfile
@@ -2,12 +2,12 @@
 
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'aws-sdk-cloudwatch'
+gem "aws-sdk-cloudwatch"
 
 group :test do
-  gem 'rspec'
-  gem 'timecop'
-  gem 'webmock'
+  gem "rspec"
+  gem "timecop"
+  gem "webmock"
 end

--- a/dns-service/metrics/lib/agent.rb
+++ b/dns-service/metrics/lib/agent.rb
@@ -1,16 +1,8 @@
 require_relative "dns_metrics"
 
-# Wait for DNS server to start
-10.times do
-  BindClient.new.get_server_stats
-rescue Errno::EADDRNOTAVAIL => e
-  sleep 1
-  next # Server is still booting so try again
-else
-  break # Server is up so we can continue
-end
+ApiChecker.new.execute
 
-while true
+loop do
   PublishMetrics.new(
     aws_client: AwsClient.new,
     bind_client: BindClient.new

--- a/dns-service/metrics/lib/agent.rb
+++ b/dns-service/metrics/lib/agent.rb
@@ -11,11 +11,9 @@ else
 end
 
 while true
-  puts "before metrics"
   PublishMetrics.new(
     aws_client: AwsClient.new,
     bind_client: BindClient.new
   ).execute
-  puts "after metrics"
   sleep 10
 end

--- a/dns-service/metrics/lib/api_checker.rb
+++ b/dns-service/metrics/lib/api_checker.rb
@@ -1,14 +1,17 @@
 class ApiChecker
   attr_reader :sleep_seconds
 
-  def initialize(sleep_seconds: 1)
+  SECONDS_TO_SLEEP_BETWEEN_CHECKS = 1
+  NUMBER_OF_API_CHECKS = 10
+
+  def initialize(sleep_seconds: SECONDS_TO_SLEEP_BETWEEN_CHECKS)
     @sleep_seconds = sleep_seconds
   end
 
   def execute
     is_up = false
 
-    10.times do
+    NUMBER_OF_API_CHECKS.times do
       BindClient.new.get_server_stats
     rescue Errno::EADDRNOTAVAIL
       sleep sleep_seconds

--- a/dns-service/metrics/lib/api_checker.rb
+++ b/dns-service/metrics/lib/api_checker.rb
@@ -1,0 +1,25 @@
+class ApiChecker
+  attr_reader :sleep_seconds
+
+  def initialize(sleep_seconds: 1)
+    @sleep_seconds = sleep_seconds
+  end
+
+  def execute
+    is_up = false
+
+    10.times do
+      BindClient.new.get_server_stats
+    rescue Errno::EADDRNOTAVAIL
+      sleep sleep_seconds
+      next # Server is still booting so try again
+    else
+      is_up = true
+      break # Server is up so we can continue
+    end
+
+    raise "BIND Stats API is not running" unless is_up
+
+    is_up
+  end
+end

--- a/dns-service/metrics/lib/aws_client.rb
+++ b/dns-service/metrics/lib/aws_client.rb
@@ -9,8 +9,6 @@ class AwsClient
   end
 
   def put_metric_data(metrics)
-    puts "#{metrics}"
-    puts "in metrics"
     sliced(metrics).each do |metrics_slice|
       client.put_metric_data(
         namespace: "DNS-Bind-Server",

--- a/dns-service/metrics/lib/dns_metrics.rb
+++ b/dns-service/metrics/lib/dns_metrics.rb
@@ -1,3 +1,4 @@
 require_relative "aws_client"
 require_relative "publish_metrics"
 require_relative "bind_client"
+require_relative "api_checker"

--- a/dns-service/metrics/spec/api_checker_spec.rb
+++ b/dns-service/metrics/spec/api_checker_spec.rb
@@ -1,0 +1,29 @@
+require_relative "spec_helper"
+
+describe ApiChecker do
+  describe "#execute" do
+    context "statistics API is up" do
+      before do
+        stub_request(:get, "localhost:8080/json/v1/server")
+          .to_return(status: 200, body: "{\"json-stats-version\": \"1.5\"}", headers: {})
+      end
+
+      it "returns true" do
+        expect(ApiChecker.new(sleep_seconds: 0).execute).to eq true
+      end
+    end
+
+    context "statistics API is down" do
+      before do
+        stub_request(:get, "localhost:8080/json/v1/server")
+          .to_raise(Errno::EADDRNOTAVAIL)
+      end
+
+      it "raises an error" do
+        expect {
+          ApiChecker.new(sleep_seconds: 0).execute
+        }.to raise_error "BIND Stats API is not running"
+      end
+    end
+  end
+end

--- a/dns-service/metrics/spec/publish_metrics_spec.rb
+++ b/dns-service/metrics/spec/publish_metrics_spec.rb
@@ -28,7 +28,7 @@ describe PublishMetrics do
     server_stats = JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/bind_api_server_stats_response.json"))
     bind_client = double(get_server_stats: server_stats, get_zone_stats: {test: "test"})
 
-    result = described_class.new(
+    described_class.new(
       aws_client: aws_client,
       bind_client: bind_client
     ).execute
@@ -108,7 +108,7 @@ describe PublishMetrics do
     zone_stats = JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/bind_api_zone_stats_response.json"))
     bind_client = double(get_server_stats: {test: "test"}, get_zone_stats: zone_stats)
 
-    result = described_class.new(
+    described_class.new(
       aws_client: aws_client,
       bind_client: bind_client
     ).execute


### PR DESCRIPTION
Allows us to add tests around the API checking logic and makes the agent as simple as possible