### PR TITLE
Update example config to match what we have in production

### DIFF
--- a/dns-service/test_named.conf
+++ b/dns-service/test_named.conf
@@ -1,18 +1,10 @@
 options {
   directory "/var/bind";
 
-  allow-recursion {
-    127.0.0.1/32;
-  };
+  allow-query { any; };
+  allow-recursion { any; };
 
-  forwarders {
-    8.8.8.8;
-    8.8.4.4;
-  };
-  
-  forward only;
-
-  listen-on { any; };
+  listen-on port 53 { any; };
   listen-on-v6 { none; };
 
   pid-file "/var/run/named/named.pid";
@@ -22,11 +14,6 @@ options {
 
 statistics-channels {
   inet 127.0.0.1 port 8080 allow { 127.0.0.1; };
-};
-
-zone "." IN {
-  type hint;
-  file "named.ca";
 };
 
 zone "localhost" IN {
@@ -41,4 +28,22 @@ zone "127.in-addr.arpa" IN {
   file "pri/127.zone";
   allow-update { none; };
   notify no;
+};
+
+zone "foobar.com" IN {
+  type forward;
+  forward only;
+  forwarders {
+    1.1.1.1;
+    2.2.2.2;
+    };
+};
+
+zone "." IN {
+  type forward;
+  forward only;
+  forwarders {
+    8.8.8.8;
+    9.9.9.9;
+  }
 };


### PR DESCRIPTION
This places the catchall zone as the last zone that we use for
forwarding. Don't define the forwarders in the options as they will
always be the first to match. Add forward only configuration to zones.