### PR TITLE
Add sentry to DNS metrics agent

### DIFF
--- a/dns-service/Dockerfile
+++ b/dns-service/Dockerfile
@@ -3,7 +3,7 @@ FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/dns:ruby-2-7-
 
 ARG EXTRA_BUNDLE_CONFIG="without 'test'"
 
-RUN apk --update upgrade && apk add bash bind bind-tools bind-plugins aws-cli \
+RUN apk --update upgrade && apk add bash bind bind-tools bind-plugins aws-cli less \
   && apk add --update --no-cache --virtual deps g++ make openssl-dev bind-dev \
   && wget https://www.dns-oarc.net/files/dnsperf/dnsperf-2.3.4.tar.gz \
   && tar zxvf dnsperf-2.3.4.tar.gz \
@@ -12,7 +12,6 @@ RUN apk --update upgrade && apk add bash bind bind-tools bind-plugins aws-cli \
   && make \
   && strip ./src/dnsperf ./src/resperf \
   && make install \
-  && apk del deps \
   && rm -rf /dnsperf-2.3.4* \
   && chmod 644 /etc/bind/rndc.key
 
@@ -24,6 +23,8 @@ COPY ./metrics ./metrics
 RUN cd metrics && \
   bundle config set no-cache 'true' ${EXTRA_BUNDLE_CONFIG} && \
   bundle install
+
+RUN apk del deps
 
 EXPOSE 53 53/udp
 

--- a/dns-service/metrics/Gemfile
+++ b/dns-service/metrics/Gemfile
@@ -5,9 +5,11 @@ source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "aws-sdk-cloudwatch"
+gem "sentry-ruby"
 
 group :test do
   gem "rspec"
   gem "timecop"
   gem "webmock"
+  gem "pry-byebug"
 end

--- a/dns-service/metrics/Gemfile.lock
+++ b/dns-service/metrics/Gemfile.lock
@@ -15,10 +15,26 @@ GEM
       jmespath (~> 1.0)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.8)
     crack (0.4.4)
     diff-lcs (1.4.4)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
     hashdiff (1.0.1)
     jmespath (1.4.0)
+    method_source (1.0.0)
+    multipart-post (2.1.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -33,6 +49,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.0)
+    ruby2_keywords (0.0.4)
+    sentry-ruby (4.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      faraday (>= 1.0)
+      sentry-ruby-core (= 4.2.2)
+    sentry-ruby-core (4.2.2)
+      concurrent-ruby
+      faraday
     timecop (0.9.2)
     webmock (3.11.0)
       addressable (>= 2.3.6)
@@ -44,7 +68,9 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-cloudwatch
+  pry-byebug
   rspec
+  sentry-ruby
   timecop
   webmock
 

--- a/dns-service/metrics/lib/agent.rb
+++ b/dns-service/metrics/lib/agent.rb
@@ -1,11 +1,47 @@
+require "sentry-ruby"
 require_relative "dns_metrics"
 
-ApiChecker.new.execute
-
-loop do
-  PublishMetrics.new(
-    aws_client: AwsClient.new,
-    bind_client: BindClient.new
-  ).execute
-  sleep 10
+Sentry.init do |config|
+  # All errors will be sent syncronously!
+  config.background_worker_threads = 0
+  config.environment = ENV["RUBY_ENV"]
 end
+
+class Agent
+  def execute
+    begin
+      api_checker.execute
+    rescue => e
+      Sentry.capture_exception(e)
+      raise e
+    end
+
+    loop do
+      begin
+        PublishMetrics.new(
+          aws_client: aws_client,
+          bind_client: bind_client
+        ).execute
+        sleep 10
+      rescue => e
+        Sentry.capture_exception(e)
+      end
+    end
+  end
+
+  private
+
+  def api_checker
+    @api_checker ||= ApiChecker.new
+  end
+
+  def aws_client
+    @aws_client ||= AwsClient.new
+  end
+
+  def bind_client
+    @bind_client ||= BindClient.new
+  end
+end
+
+Agent.new.execute

--- a/dns-service/metrics/lib/agent.rb
+++ b/dns-service/metrics/lib/agent.rb
@@ -4,7 +4,7 @@ require_relative "dns_metrics"
 Sentry.init do |config|
   # All errors will be sent syncronously!
   config.background_worker_threads = 0
-  config.environment = ENV["RUBY_ENV"]
+  config.environment = ENV["SENTRY_CURRENT_ENV"]
 end
 
 class Agent

--- a/dns-service/metrics/lib/agent.rb
+++ b/dns-service/metrics/lib/agent.rb
@@ -9,12 +9,7 @@ end
 
 class Agent
   def execute
-    begin
-      api_checker.execute
-    rescue => e
-      Sentry.capture_exception(e)
-      raise e
-    end
+    api_checker.execute
 
     loop do
       PublishMetrics.new(
@@ -22,9 +17,10 @@ class Agent
         bind_client: bind_client
       ).execute
       sleep 10
-    rescue => e
-      Sentry.capture_exception(e)
     end
+  rescue => e
+    Sentry.capture_exception(e)
+    raise e
   end
 
   private

--- a/dns-service/metrics/lib/agent.rb
+++ b/dns-service/metrics/lib/agent.rb
@@ -17,15 +17,13 @@ class Agent
     end
 
     loop do
-      begin
-        PublishMetrics.new(
-          aws_client: aws_client,
-          bind_client: bind_client
-        ).execute
-        sleep 10
-      rescue => e
-        Sentry.capture_exception(e)
-      end
+      PublishMetrics.new(
+        aws_client: aws_client,
+        bind_client: bind_client
+      ).execute
+      sleep 10
+    rescue => e
+      Sentry.capture_exception(e)
     end
   end
 

--- a/dns-service/metrics/lib/api_checker.rb
+++ b/dns-service/metrics/lib/api_checker.rb
@@ -21,8 +21,12 @@ class ApiChecker
       break # Server is up so we can continue
     end
 
-    raise "BIND Stats API is not running" unless is_up
+    raise DnsStatsApiDidNotStartError.new("BIND Stats API is not running") unless is_up
 
     is_up
   end
+
+  private
+
+  class DnsStatsApiDidNotStartError < StandardError; end
 end


### PR DESCRIPTION
Send error reports to Sentry.

This also changes behaviour aroudn the script exiting., If an error trying to check if the API is up in the first instance, an error will be reported to sentry and the script will exit.  Beyond this point if an error is encountered trying to publish metrics we will continue to retry and raise errors. This will allow the script to continue.

Co authored with @efuaakum and @neilkidd 