### PR TITLE
:arrow_up: Upgrade ruby-alpine docker image

### DIFF
--- a/dns-service/Dockerfile
+++ b/dns-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine3.12
+FROM ruby:3.1.2-alpine3.16
 
 ARG EXTRA_BUNDLE_CONFIG="without 'test'"
 


### PR DESCRIPTION
Ruby-alpine version updgraded to 3.1.2-alpine3.16

⠿ Container staff-device-dns-server-dns-1  Running                                                                                                                                      0.0s
docker-compose -f docker-compose.yml run --rm dns-test rspec ./metrics/spec
[+] Running 1/0
 ⠿ Container staff-device-dns-server-dns-1  Running                                                                                                                                      0.0s
.........

Finished in 0.02133 seconds (files took 0.3504 seconds to load)
9 examples, 0 failures