### PR TITLE
disabling dnssec-vaildation to make local dev environment inline with…

### DIFF
--- a/dns-service/test_named.conf
+++ b/dns-service/test_named.conf
@@ -9,6 +9,8 @@ options {
 
   pid-file "/var/run/named/named.pid";
 
+  dnssec-validation no;
+
   allow-transfer { none; };
 };
 


### PR DESCRIPTION
disabling dnssec-vaildation to make local dev environment inline with production config